### PR TITLE
Change example of usage with AppsFlyer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ In case of problems with no internet connection or another, the values obtained 
 ### How to get user tests for analytics?   
 
 ``` 
-let experiments = ab.experiments()
+let experiments = ab.experimentsWithDetails()
 
-// or if you need tech details
-// let experiments = ab.experimentsWithDetails()
+// or if you need experiments without tech details
+// let experiments = ab.experiments()
 
 // i.e. set Amplitude user properties
 Amplitude.instance().setUserProperties(experiments);


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Нужно чтобы по-дефолту в документации был пример с отправкой в amplitude экспериментов с префиксами (если разработчик решит делать это без префиксов – пусть это будет осознанно, а не после копипасты из документации)